### PR TITLE
feat(example): Copy svg to clipboard

### DIFF
--- a/example/components/alert.tsx
+++ b/example/components/alert.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react'
+import styled, { css, keyframes, Keyframes } from 'styled-components'
+
+const flyIn = keyframes`
+  from {
+    opacity: 0;
+    visibility: visible;
+    transform: translateX(-50%) translateY(-5px);
+  }
+  to {
+    opacity: 1;
+    visibility: visible;
+    transform: translateX(-50%) translateY(0px);
+  }
+`
+
+const fadeOut = keyframes`
+  from {
+    opacity: 1;
+    visibility: visible;
+  }
+  to {
+    opacity: 0;
+    visibility: hidden;
+  }
+`
+
+const animation = (props: {
+  animation: Keyframes
+  animationLength: number
+}) => {
+  return css`
+    animation: ${props.animation} ${props.animationLength}ms forwards ease-out;
+  `
+}
+
+const AlertWrapper = styled.div`
+  position: relative;
+  overflow: inherit;
+`
+
+const Alert = styled.div`
+  position: absolute;
+  margin-top: 5px;
+  padding: 4px 10px;
+  width: 100px;
+  z-index: 10;
+  background-color: var(--color-alert-background);
+  color: var(--color-alert-text);
+  font-weight: 500;
+  text-align: center;
+  border-radius: 3px;
+  font-size: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  opacity: 0;
+  visibility: hidden;
+
+  ${animation};
+`
+
+export default function({
+  children,
+  animationLength,
+  visibilityDuration,
+  alertText,
+  onFinish,
+}) {
+  const [alertFading, setAlertFading] = React.useState(false)
+
+  React.useEffect(() => {
+    if (alertText) {
+      setTimeout(
+        () => setAlertFading(true),
+        visibilityDuration - animationLength
+      )
+      setTimeout(() => {
+        onFinish()
+        setAlertFading(false)
+      }, visibilityDuration)
+    }
+  }, [alertText])
+
+  return (
+    <AlertWrapper>
+      {children}
+      {alertText ? (
+        <Alert
+          aria-live="polite"
+          role="alert"
+          animation={alertFading ? fadeOut : flyIn}
+          animationLength={animationLength}
+        >
+          {alertText.message}
+        </Alert>
+      ) : null}
+    </AlertWrapper>
+  )
+}

--- a/example/components/alert.tsx
+++ b/example/components/alert.tsx
@@ -39,7 +39,7 @@ const AlertWrapper = styled.div`
   overflow: inherit;
 `
 
-const Alert = styled.div`
+const StyledAlert = styled.div`
   position: absolute;
   margin-top: 5px;
   padding: 4px 10px;
@@ -59,7 +59,7 @@ const Alert = styled.div`
   ${animation};
 `
 
-export default function({
+export default function Alert({
   children,
   animationLength,
   visibilityDuration,
@@ -85,14 +85,14 @@ export default function({
     <AlertWrapper>
       {children}
       {alertText ? (
-        <Alert
+        <StyledAlert
           aria-live="polite"
           role="alert"
           animation={alertFading ? fadeOut : flyIn}
           animationLength={animationLength}
         >
           {alertText.message}
-        </Alert>
+        </StyledAlert>
       ) : null}
     </AlertWrapper>
   )

--- a/example/components/toolbar.tsx
+++ b/example/components/toolbar.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react'
-import state from '../state'
+import state, { useSelector } from '../state'
+import Alert from './alert'
+import copySvgToClipboard from '../utils/copySvgToClipboard'
 import styled from 'styled-components'
-import { Trash, RotateCcw, RotateCw, Settings } from 'react-feather'
+import { Trash, RotateCcw, RotateCw, Settings, Clipboard } from 'react-feather'
 
 const ToolbarContainer = styled.div`
   position: absolute;
@@ -16,12 +18,14 @@ const ToolbarContainer = styled.div`
   background-color: var(--color-scrim);
   backdrop-filter: blur(30px);
   user-select: none;
+  overflow: visible;
 `
 
 const ButtonGroup = styled.div`
   padding: 0 4px;
   display: flex;
   align-items: center;
+  overflow: inherit;
 `
 
 const IconButton = styled.button`
@@ -46,6 +50,8 @@ const IconButton = styled.button`
 `
 
 export default function Toolbar() {
+  const clipboardMessage = useSelector(state => state.data.clipboardMessage)
+
   return (
     <ToolbarContainer onPointerDown={e => e.stopPropagation()}>
       <ButtonGroup>
@@ -63,6 +69,20 @@ export default function Toolbar() {
         | <a href="https://twitter.com/steveruizok">@steveruizok</a>
       </div>
       <ButtonGroup>
+        <Alert
+          animationLength={150}
+          visibilityDuration={1200}
+          alertText={clipboardMessage}
+          onFinish={() => state.send('SET_CLIPBOARD_MESSAGE', null)}
+        >
+          <IconButton
+            onClick={async () => {
+              state.send('SET_CLIPBOARD_MESSAGE', await copySvgToClipboard())
+            }}
+          >
+            <Clipboard />
+          </IconButton>
+        </Alert>
         <IconButton onClick={() => state.send('TOGGLED_CONTROLS')}>
           <Settings />
         </IconButton>

--- a/example/pages/index.tsx
+++ b/example/pages/index.tsx
@@ -46,7 +46,7 @@ export default function Home() {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main>
-        <svg ref={ref} viewBox={'0 0 800 600'}>
+        <svg ref={ref} viewBox={'0 0 800 600'} id="drawable-svg">
           {marks.map((mark, i) => (
             <path
               key={i}

--- a/example/state.ts
+++ b/example/state.ts
@@ -1,6 +1,6 @@
 import { createState, createSelectorHook } from '@state-designer/react'
 import { getPointer } from './hooks/useEvents'
-import { Mark, CompleteMark } from './types'
+import { Mark, CompleteMark, ClipboardMessage } from './types'
 import pathAlgorithm, { StrokeOptions } from 'perfect-freehand'
 
 const defaultOptions: StrokeOptions = {
@@ -29,6 +29,7 @@ const state = createState({
     redos: [] as { clear?: boolean; marks: CompleteMark[] }[],
     marks: [] as CompleteMark[],
     currentMark: null as Mark | null,
+    clipboardMessage: null as ClipboardMessage | null,
   },
   on: {
     RESET_OPTIONS: [d => (d.alg = { ...defaultOptions }), 'updatePaths'],
@@ -51,6 +52,7 @@ const state = createState({
     UNDO: ['undoMark'],
     REDO: ['redoMark'],
     TOGGLED_DARK_MODE: ['toggleDarkMode', 'setDarkMode'],
+    SET_CLIPBOARD_MESSAGE: (d, p) => (d.clipboardMessage = p),
   },
   states: {
     pointer: {

--- a/example/styles/globals.css
+++ b/example/styles/globals.css
@@ -11,12 +11,16 @@ html,
   --color-border: rgba(144, 144, 144, 0.4);
   --color-hover: rgba(144, 144, 144, 0.1);
   --color-scrim: rgba(255, 255, 255, 0.9);
+  --color-alert-background: #2d2d2d;
+  --color-alert-text: #ffffff;
 }
 
 .dark {
   --color-background: #1d1d1d;
   --color-text: #cfcfcf;
   --color-scrim: rgba(20, 0, 0, 0.3);
+  --color-alert-background: #ffffff;
+  --color-alert-text: #1d1d1d;
 }
 
 button {

--- a/example/styles/globals.css
+++ b/example/styles/globals.css
@@ -11,7 +11,7 @@ html,
   --color-border: rgba(144, 144, 144, 0.4);
   --color-hover: rgba(144, 144, 144, 0.1);
   --color-scrim: rgba(255, 255, 255, 0.9);
-  --color-alert-background: #2d2d2d;
+  --color-alert-background: #1d1d1d;
   --color-alert-text: #ffffff;
 }
 

--- a/example/types.ts
+++ b/example/types.ts
@@ -35,3 +35,8 @@ export interface Pointer extends Point {
   p: number
   type: 'pen' | 'mouse' | 'touch'
 }
+
+export interface ClipboardMessage {
+  error: boolean
+  message: string
+}

--- a/example/utils/copySvgToClipboard.ts
+++ b/example/utils/copySvgToClipboard.ts
@@ -1,0 +1,30 @@
+export default async function() {
+  const element = document.getElementById('drawable-svg')
+
+  let clipboardMessage = null
+  if (element) {
+    const s = new XMLSerializer()
+    const svgString = s.serializeToString(element)
+
+    await navigator.clipboard.writeText(svgString).then(
+      () => {
+        clipboardMessage = {
+          error: false,
+          message: `Copied SVG`,
+        }
+      },
+      () => {
+        clipboardMessage = {
+          error: true,
+          message: `Unable to copy svg`,
+        }
+      }
+    )
+  } else {
+    clipboardMessage = {
+      error: true,
+      message: `Couldn't find svg`,
+    }
+  }
+  return clipboardMessage
+}

--- a/example/utils/copySvgToClipboard.ts
+++ b/example/utils/copySvgToClipboard.ts
@@ -1,10 +1,29 @@
-export default async function() {
-  const element = document.getElementById('drawable-svg')
-
+export default async function copySvgToClipboard() {
   let clipboardMessage = null
+
+  const element = document.getElementById('drawable-svg') as any
+
   if (element) {
+    // Get the SVG's bounding box
+    var bbox = element.getBBox()
+    let tViewBox = element.getAttribute('viewBox')
+    var viewBox = [bbox.x, bbox.y, bbox.width, bbox.height].join(' ')
+    let tW = element.getAttribute('width')
+    let tH = element.getAttribute('height')
+
+    // Resize the element to the bounding box
+    element.setAttribute('viewBox', viewBox)
+    element.setAttribute('width', bbox.width)
+    element.setAttribute('height', bbox.height)
+
+    // Take a snapshot of the element
     const s = new XMLSerializer()
     const svgString = s.serializeToString(element)
+
+    // Reset the element to its original viewBox / size
+    element.setAttribute('viewBox', tViewBox)
+    element.setAttribute('width', tW)
+    element.setAttribute('height', tH)
 
     await navigator.clipboard.writeText(svgString).then(
       () => {

--- a/example/utils/copySvgToClipboard.ts
+++ b/example/utils/copySvgToClipboard.ts
@@ -7,7 +7,12 @@ export default async function copySvgToClipboard() {
     // Get the SVG's bounding box
     var bbox = element.getBBox()
     let tViewBox = element.getAttribute('viewBox')
-    var viewBox = [bbox.x, bbox.y, bbox.width, bbox.height].join(' ')
+    var viewBox = [
+      bbox.x - 16,
+      bbox.y - 16,
+      bbox.width + 32,
+      bbox.height + 32,
+    ].join(' ')
     let tW = element.getAttribute('width')
     let tH = element.getAttribute('height')
 


### PR DESCRIPTION
Thanks a bunch for developing this super fun library. While using your repo's example app for a recent project of mine I needed to copy the drawn svg element into Sketch to build out a design.

I thought it'd be super handy to have a copy to clipboard button so that you can copy and paste directly into a design tool like Figma/Sketch. Check out a gif below. 

![copy-to-clipboard](https://user-images.githubusercontent.com/39874506/109420196-0a1d1e80-79c9-11eb-90e0-028f135b989d.gif)

I tried to make the feature code idiomatic of how you've been building it using your state library (a neat little rabbit hole of investigation) while making sure not to add any extra dependencies.

I wasn't sure precisely whether I could include the [async util fn for clipboard copying](https://github.com/miles-crighton/perfect-freehand/blob/copy-svg-to-clipboard/example/utils/copySvgToClipboard.ts) to the createState object. First I tried simply putting it an `action` but the proxy to the data was revoked. I then tried using the [asyncs example](https://state-designer.com/docs/api/design#asyncs) in the docs, but couldn't figure out how to directly invoke the async function using `on` event chains.

So, I settled on just dispatching the action after the async clipboard utility returned the appropriate message.

I also created a small accessible alert component for letting the user know the result of the copy request. It color adjusts appropriately for light and dark mode.

Hopefully this might be of interest for adding to the example, let me know. If not, thanks again for building these libraries. 👍 