### PR TITLE
Update README with correct default option value

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The options object is optional, as are each of its properties.
 | `easing`           | function | t => t  | An easing function to apply to each point's pressure. |
 | `start`            | { }      |         | Tapering options for the start of the line.           |
 | `end`              | { }      |         | Tapering options for the end of the line.             |
-| `last`             | boolean  | true    | Whether the stroke is complete.                       |
+| `last`             | boolean  | false   | Whether the stroke is complete.                       |
 
 **Note:** When the `last` property is `true`, the line's end will be drawn at the last input point, rather than slightly behind it.
 


### PR DESCRIPTION
Hey Steve! Thanks a ton for this library 🙏 

As far as I can tell, `last` actually defaults to `false`, as setting it `true` in our app makes a clear difference. This also seems to be confirmed from looking at the code [here](https://github.com/steveruizok/perfect-freehand/blob/ff2500c020a3d617cca676eb43d430099b841f06/packages/perfect-freehand/src/getStrokeOutlinePoints.ts) and [here](https://github.com/steveruizok/perfect-freehand/blob/b82dc3e526ca11153756d4b4eb72748e3cce0a94/packages/perfect-freehand/src/getStrokePoints.ts).

Rather than change the behavior to match the doc, I figured I'd update the doc to match the behavior.
