### PR TITLE
Double hot path perf, halve payload size, maintain readability

### DIFF
--- a/packages/dev/src/state/shapes/draw.tsx
+++ b/packages/dev/src/state/shapes/draw.tsx
@@ -233,23 +233,17 @@ export class DrawUtil extends TLShapeUtil<T, E> {
 
 const average = (a: number, b: number) => (a + b) / 2
 
-function getSvgPathFromStroke(points: number[][]): string {
-  const len = points.length
+function getSvgPathFromStroke(points: {xs: number[], ys: number[]}): string {
+  const len = xs.length
 
   if (!len) {
     return ''
   }
 
-  const first = points[0]
-  let result = `M${first[0].toFixed(3)},${first[1].toFixed(3)}Q`
+  let result = `M${xs[0].toFixed(3)},${ys[0].toFixed(3)}Q`
 
   for (let i = 0, max = len - 1; i < max; i++) {
-    const a = points[i]
-    const b = points[i + 1]
-    result += `${a[0].toFixed(3)},${a[1].toFixed(3)} ${average(
-      a[0],
-      b[0]
-    ).toFixed(3)},${average(a[1], b[1]).toFixed(3)} `
+    result += `${xs[i].toFixed(3)},${ys[i].toFixed(3)} ${average(xs[i], xs[i + 1]).toFixed(3)},${average(ys[i], ys[i + 1]).toFixed(3)} `
   }
 
   result += 'Z'

--- a/packages/dev/src/state/shapes/draw.tsx
+++ b/packages/dev/src/state/shapes/draw.tsx
@@ -240,10 +240,13 @@ function getSvgPathFromStroke(points: {xs: number[], ys: number[]}): string {
     return ''
   }
 
-  let result = `M${xs[0].toFixed(2)},${ys[0].toFixed(2)}Q`
+  let x0 = xs[0], y0 = ys[0], x1 = xs[1], y1 = ys[1], x2 = xs[2], y2 = ys[2]
+  let result = `M${x0.toFixed(2)},${y0.toFixed(2)}
+    Q ${x1.toFixed(2)},${y1.toFixed(2)} ${average(x1, x2).toFixed(2)},${average(y1, y2).toFixed(2)}
+    T `;
 
-  for (let i = 0, max = len - 1; i < max; i++) {
-    result += `${xs[i].toFixed(2)},${ys[i].toFixed(2)} ${average(xs[i], xs[i + 1]).toFixed(2)},${average(ys[i], ys[i + 1]).toFixed(2)} `
+  for (let i = 0, max = len - 1; i < max; i++) { // TODO: bound check, start at > 0, etc.
+    result += `${average(xs[i], xs[i+1]).toFixed(2)},${average(ys[i], ys[i+1]).toFixed(2)} `;
   }
 
   result += 'Z'

--- a/packages/dev/src/state/shapes/draw.tsx
+++ b/packages/dev/src/state/shapes/draw.tsx
@@ -240,10 +240,10 @@ function getSvgPathFromStroke(points: {xs: number[], ys: number[]}): string {
     return ''
   }
 
-  let result = `M${xs[0].toFixed(3)},${ys[0].toFixed(3)}Q`
+  let result = `M${xs[0].toFixed(2)},${ys[0].toFixed(2)}Q`
 
   for (let i = 0, max = len - 1; i < max; i++) {
-    result += `${xs[i].toFixed(3)},${ys[i].toFixed(3)} ${average(xs[i], xs[i + 1]).toFixed(3)},${average(ys[i], ys[i + 1]).toFixed(3)} `
+    result += `${xs[i].toFixed(2)},${ys[i].toFixed(2)} ${average(xs[i], xs[i + 1]).toFixed(2)},${average(ys[i], ys[i + 1]).toFixed(2)} `
   }
 
   result += 'Z'


### PR DESCRIPTION
Follow-up to https://twitter.com/_chenglou/status/1570895293784391681 and https://twitter.com/_chenglou/status/1567269585585606659 which turned into some nice discussions. PR not meant to be merged. Feel free to take various bits back into the codebase.

The goal is to improve tldraw and perfect-freehand’s UX and DX through perf improvements. Generally, perf can be obtained either by complicating things, or by simplifying things. Imo we don’t do enough of the latter, so I’d like to show some examples here.

`getSvgPathFromStroke` turns a list of coordinates into a path string for SVG. It’s the hottest paths in perfect-freehand, which is used in tldraw, and one of the hottest path there as well, as Steve benchmarked.

## First commit
This is a classic graphics programming array-of-structure to structure-of-array transform where we turn the points data structure `Array<[number, number]>` into `{xs: Array<number>, ys: Array<number>}`. **You don’t need this**. I believe we’re settling with `Array<{x: number, y: number}>` which is better readability and good enough perf increase compared to the current format. For more info, see the previous 2 links.

(There’s a 0th commit which turns string concats into string interpolation, also elaborated in the first tweet. Together they improve this hot path by 8-10%).

## Second commit
This turns `toFixed(3)` into `toFixed(2) for another 10% overall perf boost (!). `toFixed` is disproportionally the hottest call here, although it’s already the most performant way to turn numbers into strings (again, benchmark to see whether it’s true for your own codebase. It’s likely not). Perfect-freehand, and tldraw by extension, already work with 2 decimal points, so a third one isn’t needed. No readability decrease.

## Third commit
`toFixed` is so hot that there’s basically no point spending effort optimizing anything else. So the third commit aims at it. We’re using the [`Q` command of `<path>`’s `d` attribute](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d) to create quadratic Bézier curves passing by `average(point_i, point_(i+1)`. Each `Q` command takes in 4 numbers. I was thinking that, if there’s a way to use fewer numbers, then we’d have solved this bottleneck. Fortunately there’s exactly `T`, which implicitly assumes the control point using a reflection (more info in the link). Now instead of using 4 `Q` numbers, we use 2 `T` numbers. This also improves readability.
![Scanned Documents](https://user-images.githubusercontent.com/1909539/190894986-e244881c-dfdf-4516-8391-17a7e13bc062.jpg)

Halving the numbers halved the calls to `toFixed`, which gives 200% perf boost along with the earlier commits. These also halved the payload size for the path. And since perfect-freehand and tldraw’s payload size (?) is dominated by Bézier curve paths, this theoretically halves all downstream sharing of their output.

## Lessons
- Profile first. One’s chance of guessing exactly the right line of code causing problems in a big codebase nears 0%. Conversely, any kind of architecture, dependency and caching added without profiling are likely based on the wrong assumptions. Thankfully, Steve did here.
- Generic optimizations are nice when they improve readability too.
- But nothing beats knowing the domain and applying specific optimizations for performance and readability. This has been true for https://twitter.com/_chenglou/status/1570895293784391681 as well, where the domain-specific knowledge of `sin` and `cos` in `getOutline` blew all the other generic optimizations out of the water. The stronger your codebases’ assumptions, the better. Blindly future-proofing with generic abstract architecture removes both critical perf and readability improvement opportunities.

Btw, these changes look simply (that’s the goal) but could have gone out of control if we weren’t careful. None of this acrobatics would have been necessary if DOM was fast and/or just took a data structure of points instead of asking us to serialize into a string, only for it to deserialize again anyway.