### PR TITLE
Use the .mjs file extension for the esm build

### DIFF
--- a/packages/perfect-freehand/package.json
+++ b/packages/perfect-freehand/package.json
@@ -25,12 +25,12 @@
     ".": {
       "types": "./dist/types/index.d.ts",
       "require": "./dist/cjs/index.js",
-      "import": "./dist/esm/index.js"
+      "import": "./dist/esm/index.mjs"
     }
   },
   "license": "MIT",
   "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "module": "./dist/esm/index.mjs",
   "types": "./dist/types/index.d.ts",
   "typings": "./dist/types/index.d.ts",
   "scripts": {

--- a/packages/perfect-freehand/package.json
+++ b/packages/perfect-freehand/package.json
@@ -21,6 +21,13 @@
   "files": [
     "dist/**/*"
   ],
+  "exports": {
+    ".": {
+      "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.js",
+      "import": "./dist/esm/index.js"
+    }
+  },
   "license": "MIT",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",

--- a/packages/perfect-freehand/scripts/build.js
+++ b/packages/perfect-freehand/scripts/build.js
@@ -25,6 +25,7 @@ async function main() {
     target: 'es6',
     tsconfig: './tsconfig.build.json',
     metafile: true,
+    outExtension: { '.js': '.mjs' },
   })
 
   let esmSize = 0
@@ -32,7 +33,7 @@ async function main() {
     esmSize += output.bytes
   })
 
-  fs.readFile('./dist/esm/index.js', (_err, data) => {
+  fs.readFile('./dist/esm/index.mjs', (_err, data) => {
     gzip(data, (_err, result) => {
       console.log(
         `✔ ${name}: Built package. ${(esmSize / 1000).toFixed(2)}kb (${(


### PR DESCRIPTION
This PR is a follow-up to https://github.com/steveruizok/perfect-freehand/pull/55, which fixed the CommonJS error reported in https://github.com/steveruizok/perfect-freehand/issues/53. The `.js` file extension of the esm build causes Vite to parse it as a CommonJS module causing errors. Changing the esm build file extension to `.mjs` fixes the issue.