### PR TITLE
fix: Rendering part code

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,33 +267,24 @@ const average = (a, b) => (a + b) / 2
 function getSvgPathFromStroke(points, closed = true) {
   const len = points.length
 
-  if (len < 4) {
-    return ``
-  }
+  if (len < 4) { return `` }
 
   let a = points[0]
   let b = points[1]
   const c = points[2]
 
-  let result = `M${a[0].toFixed(2)},${a[1].toFixed(2)} Q${b[0].toFixed(
-    2
-  )},${b[1].toFixed(2)} ${average(b[0], c[0]).toFixed(2)},${average(
-    b[1],
-    c[1]
-  ).toFixed(2)} T`
+  let result = `M${a[0].toFixed(2)},${a[1].toFixed(2)} 
+    Q${b[0].toFixed(2)}, ${b[1].toFixed(2)} ${average(b[0],
+    c[0]).toFixed(2)},${average(b[1], c[1]).toFixed(2)} T`
 
   for (let i = 2, max = len - 1; i < max; i++) {
     a = points[i]
     b = points[i + 1]
-    result += `${average(a[0], b[0]).toFixed(2)},${average(a[1], b[1]).toFixed(
-      2
-    )} `
+    result += `${average(a[0], b[0]).toFixed(2)},${average(a[1], b[1]).toFixed(2)}` + ` `
   }
 
-  if (closed) {
-    result += 'Z'
-  }
-
+  if (closed) { result += 'Z' }
+  
   return result
 }
 ```


### PR DESCRIPTION
on rendering part 
![image](https://github.com/user-attachments/assets/e3752f57-f93d-4c50-9936-0a31ebdf1994)

changed to 
![image](https://github.com/user-attachments/assets/412485dc-d245-42d2-87d3-efea7c8df886)

for better readability 
on for loop changed to this 
![image](https://github.com/user-attachments/assets/02278c8b-df33-479d-bed6-566d30b138ce)
for by mistake not removing space when formatting code 
